### PR TITLE
allow to pass configuration to babel

### DIFF
--- a/demo/build.config.js
+++ b/demo/build.config.js
@@ -9,6 +9,14 @@
         'es6': '../es6'
     },
 
+    'config': {
+        'es6': {
+            'resolveModuleSource': function(source) {
+                return 'es6!'+source;
+            }
+        }
+    },
+
     'exclude': ['babel'],
 
     'optimize': 'none',

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,13 @@
     <script src="libs/requirejs.min.js"></script>
     <script>
         requirejs.config({
+            config: {
+              es6: {
+                resolveModuleSource: function(source) {
+                  return 'es6!'+source;
+                }
+              }
+            },
             paths: {
                 es6: '../es6',
                 babel: '../babel-4.6.6.min'

--- a/demo/main-built.js
+++ b/demo/main-built.js
@@ -2,8 +2,10 @@ var fetchText, _buildMap = {};
 
 
 define('es6',[
-    ], function(
-        ) {
+        'module'
+], function(
+        _module
+    ) {
     return {
         load: function (name, req, onload, config) {
                     },
@@ -18,7 +20,7 @@ define('es6',[
 
 
 define('es6!src/sum',["exports", "module"], function (exports, module) {
-  
+  "use strict";
 
   module.exports = function (a, b) {
     return a + b;
@@ -26,7 +28,7 @@ define('es6!src/sum',["exports", "module"], function (exports, module) {
 });
 
 define('es6!src/class',["exports", "es6!src/sum"], function (exports, _es6SrcSum) {
-    
+    "use strict";
 
     var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 

--- a/demo/src/class.js
+++ b/demo/src/class.js
@@ -1,4 +1,4 @@
-import sum from 'es6!src/sum';
+import sum from 'src/sum';
 
 console.log( sum(1,2) );
 

--- a/es6.js
+++ b/es6.js
@@ -27,30 +27,41 @@ if (typeof window !== "undefined" && window.navigator && window.document) {
 
 define([
     //>>excludeStart('excludeBabel', pragmas.excludeBabel)
-    'babel'
+    'babel',
     //>>excludeEnd('excludeBabel')
+    'module'
 ], function(
     //>>excludeStart('excludeBabel', pragmas.excludeBabel)
-    babel
+    babel,
     //>>excludeEnd('excludeBabel')
+    _module
     ) {
     return {
         load: function (name, req, onload, config) {
             //>>excludeStart('excludeBabel', pragmas.excludeBabel)
-            var url = req.toUrl(name + '.js');
-
-            fetchText(url, function (text) {
-                var code = babel.transform(text, {
+            function applyOptions(options) {
+                var defaults = {
                     modules: 'amd',
                     sourceMap: config.isBuild ? false :'inline',
                     sourceFileName: name
-                }).code;
+                };
+                for(var key in options) {
+                    if(options.hasOwnProperty(key)) {
+                        defaults[key] = options[key];
+                    }
+                }
+                return defaults;
+            }
+            var url = req.toUrl(name + '.js');
+
+            fetchText(url, function (text) {
+                var code = babel.transform(text, applyOptions(_module.config())).code;
 
                 if (config.isBuild) {
                     _buildMap[name] = code;
                 }
 
-                onload.fromText(code);    
+                onload.fromText(code); 
             });
             //>>excludeEnd('excludeBabel')
         },


### PR DESCRIPTION
Babel have [a lot of options](http://babeljs.io/docs/usage/options/) and it would be good to have an ability to set them.

I've updated the demo where you can see how to use it. Also it help me to fix #7 because now I can provide desired option into babel and any other still will have the default behavior