### PR TITLE
Include the file extension for `sourceFileName`

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -43,7 +43,7 @@ define([
                 var defaults = {
                     modules: 'amd',
                     sourceMap: config.isBuild ? false :'inline',
-                    sourceFileName: name
+                    sourceFileName: name + '.js'
                 };
                 for(var key in options) {
                     if(options.hasOwnProperty(key)) {


### PR DESCRIPTION
Source maps expect `sources[]` entries to refer to the original file.
`sourceFileName` should include the file extension instead of using just
the RequireJS module name.

Including the extension also avoids conflicts between directory and file
names in common cases such as:

  - /path/to
    - module.js
    - module
      - submodule.js

Without the extension on `module.js`, the debugger will likely hide either
the file or all of the files in the directory.