### PR TITLE
Fix demo to run against IE11

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,9 +7,16 @@
 <body>
     Open console tab in dev tools!
 
+    <script src="../node_modules/@babel/polyfill/dist/polyfill.js"></script>
+
     <script src="../node_modules/requirejs/require.js"></script>
     <script>
         requirejs.config({
+            config: {
+                es6: {
+                    presets: ['es2015']
+                }
+            },
             paths: {
                 es6: '../es6',
                 babel: '../node_modules/@babel/standalone/babel.min',

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,9 +294,9 @@
       "optional": true
     },
     "babel-plugin-module-resolver-standalone": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver-standalone/-/babel-plugin-module-resolver-standalone-0.0.1.tgz",
-      "integrity": "sha512-GbM5QlH2/iflJqSlJFH0w9QcikTjMAo+YDhYSX1PMHKj7JdIC+Q4qEpDQsbwk5HaGUvOayIFjJiHgXsuddflSQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver-standalone/-/babel-plugin-module-resolver-standalone-0.0.2.tgz",
+      "integrity": "sha512-fYlFG2FSqP/VvvTY9orKLqstewiLSwv3/KYxXxAlMVp6HBq1eBG0UF+6F96DK7Flcl0JtKm/ezrjNUqolHHzEw==",
       "dev": true
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "7.4.0",
     "@babel/polyfill": "7.4.0",
     "@babel/standalone": "7.4.2",
-    "babel-plugin-module-resolver-standalone": "0.0.1",
+    "babel-plugin-module-resolver-standalone": "^0.0.2",
     "requirejs": "^2.3.6"
   }
 }


### PR DESCRIPTION
Note that demo-polyfill is still broken against IE11, but at least this makes demo/ itself run.