### PR TITLE
Do not append the .js extension to module names twice

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -66,7 +66,10 @@ define([
 return {
 //>>excludeStart('excludeBabel', pragmas.excludeBabel)
         load: function (name, req, onload, config) {
-            var sourceFileName = name + fileExtension;
+            // Paths relative to the current directory include the file extension.
+            var extensionIndex = name.length - fileExtension.length;
+            var sourceFileName = name.lastIndexOf(fileExtension) === extensionIndex ?
+                                 name : name + fileExtension;
             var url = req.toUrl(sourceFileName);
 
             if (url.indexOf('empty:') === 0) {


### PR DESCRIPTION
Paths relative to the current directory include the file extension. But the recognition is not easy, because the `name` parameter passed to the plugin is not the original module name from the source code. For example:

    import from 'src/sum'  ==> the plugin gets 'src/sum'
    import from './sum'    ==> the plugin gets 'src/sum'
    import from './sum.js' ==> the plugin gets 'src/sum.js'

RequireJS does not allow appending `.js` to module names from not relative paths. However, when writing a plugin, the `./` is not passed to it. As a workaround, I check if the `name` does not end with `.js`. Not the ultimate fix, but works probably well enough.